### PR TITLE
Version 1.2.5: Conflicting module name.

### DIFF
--- a/ocparse_generator.bat
+++ b/ocparse_generator.bat
@@ -1,0 +1,2 @@
+@echo off
+erl -noshell -pa _build\default\lib\ocparse\ebin -s ocparse_generator generate -s init stop

--- a/ocparse_stress.bat
+++ b/ocparse_stress.bat
@@ -15,8 +15,8 @@ MD ct\logs
 
 FOR /L %%G IN (1,1,%no_runs%) DO (
    ECHO ----------------------------------------------------------------------------
-   ECHO !TIME! %%G Step: test_generator.bat
-   CALL test_generator.bat
+   ECHO !TIME! %%G Step: ocparse_generator.bat
+   CALL ocparse_generator.bat
    ECHO !TIME! %%G Step: rebar3 ct
    CALL rebar3.cmd ct
 )

--- a/src/ocparse_generator.erl
+++ b/src/ocparse_generator.erl
@@ -1,4 +1,4 @@
--module(test_generator).
+-module(ocparse_generator).
 
 -export([generate/0]).
 

--- a/test_generator.bat
+++ b/test_generator.bat
@@ -1,2 +1,0 @@
-@echo off
-erl -noshell -pa _build\default\lib\ocparse\ebin -s test_generator generate -s init stop


### PR DESCRIPTION
Renaming `test_generator `to `ocparse_generator`.